### PR TITLE
update readme to have topics from the basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,14 @@ O livro em inglês está lentamente sendo migrado para o formato de *Markdown*  
   - [ ] Protocols and Extensions
   - [x] Error Handling
   - [ ] Generics
-- [ ] Language Guide
-  - [ ] The Basics
-    - [ ] Intro
-    - [ ] Constants and Variables
-    - [ ] Floating-Point Numbers (Minusculo)
-    - [ ] Type Safety and Type Inference(Pequeno)
-    - [ ] Numeric Type Conversion (Gigante)
-    - [ ] Assertions and Preconditions
-  - [ ] Basic Operators
+- [ ] The Basics
+  - [ ] Intro
+  - [ ] Constants and Variables
+  - [ ] Floating-Point Numbers (Minusculo)
+  - [ ] Type Safety and Type Inference(Pequeno)
+  - [ ] Numeric Type Conversion (Gigante)
+  - [ ] Assertions and Preconditions
+- [ ] Basic Operators
 
 Cada item dessa lista terá uma Issue. **Antes de pegar um desses items para traduzir, verifique a Issue e descubra se alguém já não está traduzindo**. Quando alguém pegar uma dessas `sessao/topico` para traduzir, terá o nome atribuído a Issue.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ O livro em inglês está lentamente sendo migrado para o formato de *Markdown*  
   - [ ] Generics
 - [ ] Language Guide
   - [ ] The Basics
+    - [ ] Intro
+    - [ ] Constants and Variables
+    - [ ] Floating-Point Numbers (Minusculo)
+    - [ ] Type Safety and Type Inference(Pequeno)
+    - [ ] Numeric Type Conversion (Gigante)
+    - [ ] Assertions and Preconditions
   - [ ] Basic Operators
 
 Cada item dessa lista terá uma Issue. **Antes de pegar um desses items para traduzir, verifique a Issue e descubra se alguém já não está traduzindo**. Quando alguém pegar uma dessas `sessao/topico` para traduzir, terá o nome atribuído a Issue.


### PR DESCRIPTION
There wasn't the topics of The Basics on the readme, for devs to choose from. I also added a "description" because the topics have a big discrepancy in size.