### PR TITLE
Documentando melhor o repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,11 @@
 
 Esse projeto tem como objetivo traduzir e disponibilizar gratuitamente em português o livro _The Swift Programming Language (swift 5.3)_.
 
-Cada item dessa lista terá uma Issue. **Antes de pegar um desses items para traduzir, verifique a Issue e descubra se alguém já não está traduzindo**. Quando alguém pegar uma dessas `sessao/topico` para traduzir, terá o nome atribuído a Issue.
+## Contribua
 
-## Convenções
+Acesse o guia [CONTRIBUTING.md](docs/CONTRIBUTING.md) e saiba como ajudar com a tradução!
 
-Para facilitar o processo de revisão e diminuir as inconsistências entre traduções, quem contribuir deverá seguir algumas convenções:
-
-- Não traduzir palavras reservadas.
-- Na dúvida entre traduzir ou não determinado termo, deixar o termo em inglês.
-- Criar Branches no padrão `sessao/topico` e traduzir por _Sessão_ e _Tópico_ (textos mais internos dentro da _Sessão_).
-- _Pull Requests_ devem ser feitos para `master`, marcando a Issue que resolvem.
-
-## Criação de Branches
-
-A tradução deverá ser feita através de Forks, com branches nomeadas por sessão e tópico, com letras minúsculas, seguindo o seguinte padrão:
-
-`nome-da-sessao/nome-do-topico`
-
-Exemplo:
-`a-swift-tour/control-flow`
-
-Caso não existam tópicos para determinada sessão, a branch deve ter somente o nome da sessão:
-`nome-da-sessao`
-
-## Pull Requests
-
-Os Pull Requests devem ser feitos diretamente para a branch `master`, e marcar a Issue que está resolvendo. A revisão será feita avaliando a tradução em si, a coerência do texto da tradução, e a coerência com as traduções anteriores.
-
-## O que já pode ser traduzido
+## Sumário
 
 O livro em inglês está lentamente sendo migrado para o formato de _Markdown_ antes de ser traduzido. A seguintes _Sessões_ já estão em formato _Markdown_ e já podem ser traduzidas através de Pull Requests:
 
@@ -351,8 +328,3 @@ O livro em inglês está lentamente sendo migrado para o formato de _Markdown_ a
     - [ ] Generic Parameter Clause
     - [ ] Generic Argument Clause
 
-## Começe Agora! 🎉
-
-Existe pouco ou nenhum material gratuito em português de Swift / Desenvolvimento iOS básico. Contribuindo com a tradução desse livro, você pode estar ajudando alguém que não tem \$\$\$ para comprar material a estudar. Além disso, você mesmo estará estudando, revisando, e aprendendo recursos da linguagem que você talvez não conheça.
-
-Com esforço coletivo, conseguiremos finalizar a tradução e facilitar o aprendizado de desenvolvimento iOS para quem não sabe inglês.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribuindo com a Tradução do Swift Book
+
+Esse projeto tem como objetivo traduzir e disponibilizar gratuitamente em português o livro _The Swift Programming Language (swift 5.3)_.
+
+Cada item dessa lista terá uma Issue. **Antes de pegar um desses items para traduzir, verifique a Issue e descubra se alguém já não está traduzindo**. Quando alguém pegar uma dessas `sessao/topico` para traduzir, terá o nome atribuído a Issue.
+
+## Convenções
+
+Para facilitar o processo de revisão e diminuir as inconsistências entre traduções, quem contribuir deverá seguir algumas convenções:
+
+- Não traduzir palavras reservadas.
+- Na dúvida entre traduzir ou não determinado termo, deixar o termo em inglês.
+- Criar Branches no padrão `sessao/topico` e traduzir por _Sessão_ e _Tópico_ (textos mais internos dentro da _Sessão_).
+- _Pull Requests_ devem ser feitos para `master`, marcando a Issue que resolvem.
+
+## Criação de Branches
+
+A tradução deverá ser feita através de Forks, com branches nomeadas por sessão e tópico, com letras minúsculas, seguindo o seguinte padrão:
+
+`nome-da-sessao/nome-do-topico`
+
+Exemplo:
+`a-swift-tour/control-flow`
+
+Caso não existam tópicos para determinada sessão, a branch deve ter somente o nome da sessão:
+`nome-da-sessao`
+
+## Pull Requests
+
+Os Pull Requests devem ser feitos diretamente para a branch `master`, e utilizar o template do repositório específico para PRs. Após terminar uma tradução, lembre-se de marcá-la como traduzida no README. A revisão será feita avaliando a tradução em si, a coerência do texto da tradução, e a coerência com as traduções anteriores.
+
+## Começe Agora! 🎉
+
+Existe pouco ou nenhum material gratuito em português de Swift / Desenvolvimento iOS básico. Contribuindo com a tradução desse livro, você pode estar ajudando alguém que não tem \$\$\$ para comprar material a estudar. Além disso, você mesmo estará estudando, revisando, e aprendendo recursos da linguagem que você talvez não conheça.
+
+Com esforço coletivo, conseguiremos finalizar a tradução e facilitar o aprendizado de desenvolvimento iOS para quem não sabe inglês.
+

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,13 @@
+## Descrição
+
+Coloque aqui uma descrição resumida das alterações realizadas. Caso envolva alguma issue em aberto, ela deve ser
+mencionada aqui usando o padrão `#<número da issue>`, dessa maneira: #1 
+
+## Discussões
+
+Essa sessão deve ser usada caso você queira pedir opinião sobre algum trecho/termo específico que você traduziu mas ficou em dúvida se fez da melhor forma. Caso não haja necessidade de usá-la, você pode remove-la da descrição do seu PR.
+
+## Checklist
+
+- [x] Tradução feita seguindo os critérios definidos no [CONTRIBUTING.md](CONTRIBUTING.md)
+- [x] Atalho para a sessão ou tópico adicionado ao sumário no [README.md](../README.md)


### PR DESCRIPTION
Criei a pasta docs, contendo:
- `pull_request_template.md` de acordo com a issue #209 
- `CONTRIBUTING.md` com as instruções de contribuição do repositório que antes estavam no `README.md`

Além disso, também tirei as instruções de contribuição do repositório do `README.md`, deixando somente uma referência para o arquivo `CONTRIBUTING.md` que está dentro da pasta `docs`.